### PR TITLE
fix red line and background for different viewports

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,33 +16,36 @@
 <body class="no-scrollbar">
   <!-- Hero section -->
   <div
-    class="h-screen w-full bg-opacity-50 bg-local bg-cover min-w-[1280px] min-h-[832px] bg-black flex items-center justify-center"
-    style="background-image: url('./public/images/Manipur_hero.png')">
-    <div class="w-full h-full top-0 left-0 absolute z-[99] bg-gradient-to-b from-black/5 to to-black">
+    class="h-screen w-full bg-opacity-50 bg-local bg-cover min-w-screen min-h-[832px] bg-black flex items-center justify-center"
+    style="background-image: url('./public/images/Manipur_hero.png'); background-size: cover; background-repeat: no-repeat; background-color: black;">
+    <div class="w-full h-full min-w-screen min-h-[832px] top-0 left-0 absolute z-[99] bg-gradient-to-b from-black/5 to to-black">
     </div>
-    <div class="flex flex-col justify-center items-start mt-16 mb-[auto] ml-[35%] mr-[auto] space-y-8 z-[100] relative">
-      <div class="inline-block place-items-start">
-        <img src="./public/images/manipurmap_hero.svg" alt="manipur map">
-      </div>
-      <div class="inline-block place-items-start bg-[#F2F2F2] w-[384px] max-w-[390px] h-auto p-[10px]">
-        <p class="text-justify text-[#FF103B] whitespace-normal font-semibold">101 D 10 H 52 M
-          SINCE INTERNET SUSPENSION
-        </p>
-      </div>
-      <div class="inline-block place-items-start w-[372px] max-w-sm">
-        <p class="text-start text-[44px] uppercase text-[#F2F2F2] -mt-14 mb-[auto] whitespace-pre-line">
-          You <span class="italic">aren&apos;t</span>
-          among the
-          <span class="italic">2.7 million</span>
-          in Manipur
-          <span class="italic">without</span>
-          internet
-          access -
-          <span class="text-[#FF103B] italic">for 100&plus; days</span>
-        </p>
+
+    <div class="w-4/5 flex justify-center z-[100]" style="border-bottom: 1.5px solid #FF103B; padding-bottom: 15px; width: 90%; min-width: 384px;">
+      <div class="flex flex-col justify-center items-start mt-16 mb-[auto] space-y-8 z-[100] relative">
+        <div class="inline-block place-items-start">
+          <img src="./public/images/manipurmap_hero.svg" alt="manipur map">
+        </div>
+        <div class="inline-block place-items-start bg-[#F2F2F2] w-[384px] max-w-[390px] h-auto p-[10px]">
+          <p class="text-justify text-[#FF103B] whitespace-normal font-semibold">101 D 10 H 52 M
+            SINCE INTERNET SUSPENSION
+          </p>
+        </div>
+        <div class="inline-block place-items-start w-[372px] max-w-sm">
+          <p class="text-start text-[44px] uppercase text-[#F2F2F2] -mt-14 mb-[auto] whitespace-pre-line">
+            You <span class="italic">aren&apos;t</span>
+            among the
+            <span class="italic">2.7 million</span>
+            in Manipur
+            <span class="italic">without</span>
+            internet
+            access -
+            <span class="text-[#FF103B] italic">for 100&plus; days</span>
+          </p>
+        </div>
       </div>
     </div>
-    <div class="w-[95%] h-[1.5px] mx-auto bg-[#FF103B] absolute bottom-40 left-0 right-0 z-[100]"></div>
+    <!--<div class="w-[95%] h-[1.5px] mx-auto bg-[#FF103B] absolute bottom-40 left-0 right-0 z-[100]"></div>-->
   </div>
   <!-- section 2 -->
 


### PR DESCRIPTION
(screenshots taken on a macbook air, chrome browser)

Earlier:

![image](https://github.com/InternetFreedomFoundation/projectManipur/assets/37668193/ec54c4cf-a04c-47b0-9440-0417e189e79d)


Now:

<img width="1440" alt="image" src="https://github.com/InternetFreedomFoundation/projectManipur/assets/37668193/e9026161-5f99-44d9-83a5-e7714eb1a797">


These changes also make the hero section work on mobile and tablet viewports.
